### PR TITLE
RecordDtoImpl - safer compareTo()

### DIFF
--- a/dto/src/main/java/it/bz/idm/bdp/dto/RecordDtoImpl.java
+++ b/dto/src/main/java/it/bz/idm/bdp/dto/RecordDtoImpl.java
@@ -43,7 +43,8 @@ public abstract class RecordDtoImpl implements RecordDto,Comparable<RecordDtoImp
 	
 	@Override
 	public int compareTo(RecordDtoImpl o) {
-		return this.timestamp > o.timestamp ? 1:-1;
+		return this.timestamp != null && o.timestamp != null
+			? this.timestamp.compareTo(o.timestamp) : -1;
 	}
 
 	


### PR DESCRIPTION
Handle the case where one or both the timestamps are null (where I propose to return -1). When the values are set compare them using `Long.compareTo()` which tests also for equality where 0 is returned.